### PR TITLE
update dark theme to match new notion ui

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 
         .dark {
             color: rgba(255, 255, 255, 0.9);
-            background-color: rgb(47, 52, 55) !important;
+            background-color: rgb(25, 25, 25) !important;
         }
     </style>
 </head>


### PR DESCRIPTION
A recent update to the Notion dark theme has caused this theme to become out of date. This PR aims to fix that by updating the colour used by Notion-Quote to match

Pictured: Notion-Quote embedded in a workspace using the new dark theme
<img width="847" alt="old theme in context" src="https://user-images.githubusercontent.com/29228454/155318392-1e6663cc-1746-4a84-b0a3-0deba5819888.png">

Pictured: Notion-Quote with the old theme
<img width="1532" alt="with old theme" src="https://user-images.githubusercontent.com/29228454/155318335-85bc5ee0-5173-43e0-80f0-2bea9bda809c.png">

Pictured: Notion-Quote with the new theme
<img width="1532" alt="with new theme" src="https://user-images.githubusercontent.com/29228454/155318188-01e1bfd1-fdb6-47e5-a7cf-fce3d667c07e.png">

> I had some difficulties getting this to render in Notion as an embed - any guidance you have on how to get this to work would be greatly appreciated 💙 